### PR TITLE
Some performance improvements

### DIFF
--- a/caterva/caterva.c
+++ b/caterva/caterva.c
@@ -304,6 +304,7 @@ caterva_array_t *caterva_empty_array_2(caterva_ctx_t *ctx, blosc2_frame *frame, 
             }
             carr->epsize *= carr->epshape[i];
         }
+        ctx->cparams.blocksize = carr->spsize * ctx->cparams.typesize;
 
         blosc2_schunk *sc = blosc2_new_schunk(ctx->cparams, ctx->dparams, frame);
         if (frame != NULL) {
@@ -1296,7 +1297,6 @@ int caterva_to_buffer_2_2(caterva_array_t *src, void *dest) {
                     }
 
                     blosc_getitem(&chunk, spi * src->spsize, src->spsize, &spart);
-
                     /* Copy each line of data from chunk to d_b */
                     int64_t s_coord_f, d_coord_f, s_a, d_a;
                     int64_t ii[CATERVA_MAXDIM];
@@ -1643,7 +1643,9 @@ int caterva_get_slice_buffer_2(void *dest, caterva_array_t *src, caterva_dims_t 
                                                                             sinc *= (int) (s_epshape[i] / s_spshape[i]);
                                                                         }
                                                                         s_start = nspart * src->spsize;
-                                                                        blosc_getitem(chunk, s_start, src->spsize, spart);
+                                                                        //blosc_getitem(chunk, s_start, src->spsize, spart);
+                                                                        blosc2_getitem_ctx(src->sc->dctx, chunk, s_start, src->spsize, spart);
+
                                                                         /* memcpy */
                                                                         for (int i = 0; i < CATERVA_MAXDIM; ++i) {
                                                                             if (jj[i] == j_start[i] && ii[i] == i_start[i]) {
@@ -1666,40 +1668,30 @@ int caterva_get_slice_buffer_2(void *dest, caterva_array_t *src, caterva_dims_t 
                                                                                             for (kk[5] = sp_start[5]; kk[5] < sp_stop[5]; ++kk[5]) {
                                                                                                 for (kk[6] = sp_start[6]; kk[6] < sp_stop[6]; ++kk[6]) {
                                                                                                     // check we are not in an empty line (padding)
-                                                                                                    bool empty_line = false;
-
-                                                                                                    for (int i = 0; i < 7; i++) {
-                                                                                                        if ((jj[i] * s_spshape[i] + kk[i]) >= s_pshape[i]) {
-                                                                                                            empty_line = true;
-                                                                                                            break;
-                                                                                                        }
-                                                                                                    }
-                                                                                                    if (! empty_line) {
-                                                                                                        // case padding in dim7
-                                                                                                        if ((jj[7] + 1) * s_spshape[7] > s_pshape[7]) {
-                                                                                                            int64_t lastn = s_pshape[7] % s_spshape[7];
-                                                                                                            if (lastn < sp_stop[7]) {
-                                                                                                                sp_stop[7] = lastn;
-                                                                                                            }
-                                                                                                        }
-                                                                                                        // Copy each line of data from spart to bdest
-                                                                                                        int64_t sp_pointer = 0;
-                                                                                                        int64_t sp_pointer_inc = 1;
-                                                                                                        for (int i = CATERVA_MAXDIM - 1; i >= 0; --i) {
-                                                                                                            sp_pointer += kk[i] * sp_pointer_inc;
-                                                                                                            sp_pointer_inc *= s_spshape[i];
-                                                                                                        }
-                                                                                                        int64_t buf_pointer = 0;
-                                                                                                        int64_t buf_pointer_inc = 1;
-                                                                                                        for (int i = CATERVA_MAXDIM - 1; i >= 0; --i) {
-                                                                                                            buf_pointer += (kk[i] + s_spshape[i] * jj[i] + s_pshape[i] * ii[i] -
-                                                                                                                            start_[i]) * buf_pointer_inc;
-                                                                                                            buf_pointer_inc *= d_pshape_[i];
-                                                                                                        }
-                                                                                                        memcpy(&bdest[buf_pointer * typesize],
-                                                                                                               &spart[sp_pointer * typesize],
-                                                                                                               (sp_stop[7] - sp_start[7]) * typesize);
-                                                                                                    }
+                                                                                                      // case padding in dim7
+                                                                                                      if ((jj[7] + 1) * s_spshape[7] > s_pshape[7]) {
+                                                                                                          int64_t lastn = s_pshape[7] % s_spshape[7];
+                                                                                                          if (lastn < sp_stop[7]) {
+                                                                                                              sp_stop[7] = lastn;
+                                                                                                          }
+                                                                                                      }
+                                                                                                      // Copy each line of data from spart to bdest
+                                                                                                      int64_t sp_pointer = 0;
+                                                                                                      int64_t sp_pointer_inc = 1;
+                                                                                                      for (int i = s_ndim - 1; i >= 0; --i) {
+                                                                                                          sp_pointer += kk[i] * sp_pointer_inc;
+                                                                                                          sp_pointer_inc *= s_spshape[i];
+                                                                                                      }
+                                                                                                      int64_t buf_pointer = 0;
+                                                                                                      int64_t buf_pointer_inc = 1;
+                                                                                                      for (int i = s_ndim - 1; i >= 0; --i) {
+                                                                                                          buf_pointer += (kk[i] + s_spshape[i] * jj[i] + s_pshape[i] * ii[i] -
+                                                                                                                          start_[i]) * buf_pointer_inc;
+                                                                                                          buf_pointer_inc *= d_pshape_[i];
+                                                                                                      }
+                                                                                                      memcpy(&bdest[buf_pointer * typesize],
+                                                                                                             &spart[sp_pointer * typesize],
+                                                                                                             (sp_stop[7] - sp_start[7]) * typesize);
                                                                                                 }
                                                                                             }
                                                                                         }

--- a/examples/caterva_get_slice_2.c
+++ b/examples/caterva_get_slice_2.c
@@ -13,14 +13,22 @@
 
 int main(){
     // Create a context
-    caterva_ctx_t *ctx = caterva_new_ctx(NULL, NULL, BLOSC2_CPARAMS_DEFAULTS, BLOSC2_DPARAMS_DEFAULTS);
+    blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+    cparams.compcode = BLOSC_BLOSCLZ;
+    caterva_ctx_t *ctx = caterva_new_ctx(NULL, NULL, cparams, BLOSC2_DPARAMS_DEFAULTS);
     ctx->cparams.typesize = sizeof(double);
 
     // Define the partition shape for the first array
     const int8_t ndim = 3;
-    int64_t shape_[] = {252, 252, 252};
+    const int64_t dimx = 500, dimy = 500, dimz = 500;
+    int64_t shape_[] = {dimx, dimy, dimz};
     int64_t pshape_[] = {64, 64, 64};
-    int64_t spshape_[] = {15, 15, 15};
+    int64_t spshape_[] = {16, 16, 16};
+    // int64_t start_[] = {0, 0, 0};  // 3-d slice
+    // int64_t start_[] = {dimx - 1, 0, 0};  // 2-d slice
+    int64_t start_[] = {0, dimy - 1, 0};  // 2-d slice
+    // int64_t start_[] = {dimx - 1, dimy - 1, 0};  // 1-d slice
+    int64_t stop_[] = {dimx, dimy, dimz};
 
     blosc_timestamp_t last, current;
     caterva_dims_t shape = caterva_new_dims(shape_, ndim);
@@ -41,9 +49,7 @@ int main(){
     caterva_array_t *cat2 = caterva_empty_array_2(ctx, NULL, &pshape, &spshape);
     caterva_from_buffer_2(cat2, &shape, buf_src);
 
-    int64_t start_[] = {47, 0, 0};
     caterva_dims_t start = caterva_new_dims(start_, ndim);
-    int64_t stop_[] = {48, 252, 252};
     caterva_dims_t stop = caterva_new_dims(stop_, ndim);
 
     uint64_t dest_size = 1;

--- a/examples/caterva_to_buffer_2.c
+++ b/examples/caterva_to_buffer_2.c
@@ -23,7 +23,7 @@ int main(){
     const int8_t ndim = 3;
     int64_t shape_[] = {252, 252, 252};
     int64_t pshape_[] = {64, 64, 64};
-    int64_t spshape_[] = {16, 16, 16};
+    int64_t spshape_[] = {15, 15, 15};
 
     int64_t buf_size = 1;
     for (int i = 0; i < ndim; ++i) {

--- a/tests/test_to_buffer_3.c
+++ b/tests/test_to_buffer_3.c
@@ -12,12 +12,6 @@
 #include "test_common.h"
 #include "time.h"
 
-double get_usec_chunk(blosc_timestamp_t last, blosc_timestamp_t current,
-                      int niter_) {
-    double elapsed_usecs = 1e-3 * blosc_elapsed_nsecs(last, current);
-    return (elapsed_usecs / (double) niter_);
-}
-
 static void test_to_buffer_3(caterva_ctx_t *ctx, int8_t ndim, int64_t *shape_, int64_t *pshape_, int64_t *spshape_,
                             double *result) {
 
@@ -44,14 +38,7 @@ static void test_to_buffer_3(caterva_ctx_t *ctx, int8_t ndim, int64_t *shape_, i
 
     double *buf_dest = (double *) malloc((size_t)buf_size * src->ctx->cparams.typesize);
 
-    int niter = 10;
-    blosc_set_timestamp(&last);
-    for (int i = 0; i < niter; i++) {
-        caterva_to_buffer_3(src, buf_dest);
-    }
-    blosc_set_timestamp(&current);
-    double tt = get_usec_chunk(last, current, niter);
-    printf("Tiempo: %f", tt);
+    caterva_to_buffer_3(src, buf_dest);
 
     assert_buf(buf_dest, result, (size_t)src->size, 1e-14);
     free(buf_src);


### PR DESCRIPTION
This improves speed by:

    Making the blocksize in the super-chunk to be the same size than the Caterva sub-partition

    Using blosc2_getitem_ctx() instead of plain blosc_get_item() (minor improvement).

With that, we are getting performance that is quite close to the expected optimal (but more tests are needed).